### PR TITLE
Handle stub data without crashing

### DIFF
--- a/src/containers/NearMe.js
+++ b/src/containers/NearMe.js
@@ -44,7 +44,7 @@ class NearMe extends Component {
           dataSource={washrooms}
           renderItem={(item) => (
             <List.Item>
-              {item}
+              {item.title}
             </List.Item>
           )}
         />

--- a/src/containers/__tests__/NearMe.test.js
+++ b/src/containers/__tests__/NearMe.test.js
@@ -16,7 +16,13 @@ export default function setupStore(initialState) {
 
 const store = setupStore({});
 
-fetchMock.get('https://testapi.com/washrooms', ['Washroom 1', 'Washroom 2']);
+fetchMock.get('https://testapi.com/washrooms', [
+  {
+    title: 'Washroom 1',
+  }, {
+    title: 'Washroom 2',
+  },
+]);
 
 describe('NearMe', () => {
   it('Renders the "Near me" page', async () => {


### PR DESCRIPTION
`/washrooms` now returns array of objects rather than an array of strings. 

Modify the code to not break as a result.
