### PR TITLE
Fix token refresh on initial page load

### DIFF
--- a/src/services/Auth.js
+++ b/src/services/Auth.js
@@ -8,6 +8,8 @@ export default class Auth {
   static refreshAttempted = false;
 
   static async attemptLogin() {
+    await Auth.refreshLogin();
+
     const params = new URLSearchParams(window.location.search);
 
     if (!Auth.authenticated()) {


### PR DESCRIPTION
Closes #50

When we attempt to login, refresh the login.