### PR TITLE
Fix the bug introduced in the last bug fix

### DIFF
--- a/src/services/Auth.js
+++ b/src/services/Auth.js
@@ -8,21 +8,18 @@ export default class Auth {
   static refreshAttempted = false;
 
   static async attemptLogin() {
-    await Auth.refreshLogin();
-
     const params = new URLSearchParams(window.location.search);
 
     if (!Auth.authenticated()) {
       if (params.has('code')) {
         const response = await this.fetchTokens(params.get('code'));
 
-        // clear the query parameter
-        window.location.href = window.location.origin;
-
         return response.ok;
       }
       return false;
     }
+    await Auth.refreshLogin();
+
     return true;
   }
 


### PR DESCRIPTION
Only refresh the login if the user is authenticated.

Also, remove the stripping of the query parameter of the code, as it causes some weird reloading conditions.