### PR TITLE
Export Mapbox Tokens from GitHub secrets to `.env` files 

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -14,6 +14,11 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
+    - uses: TickX/var-to-dotenv@v1.1.1
+      with:
+        key: 'REACT_APP_MAPBOX_TOKEN'
+        value: ${{ secrets.MAPBOX_DEV_TOKEN }}
+        envPath: '.env.development'
     - run: yarn install
     - run: yarn build:development
     - uses: jakejarvis/s3-sync-action@master

--- a/.github/workflows/deploy-master.yml
+++ b/.github/workflows/deploy-master.yml
@@ -14,6 +14,11 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 12.x
+    - uses: TickX/var-to-dotenv@v1.1.1
+      with:
+        key: 'REACT_APP_MAPBOX_TOKEN'
+        value: ${{ secrets.MAPBOX_PROD_TOKEN }}
+        envPath: '.env.production'
     - run: yarn install
     - run: yarn build
     - uses: jakejarvis/s3-sync-action@master

--- a/src/App.js
+++ b/src/App.js
@@ -100,4 +100,8 @@ App.propTypes = {
   store: PropTypes.shape({}).isRequired,
 };
 
+if ('REACT_APP_MAPBOX_TOKEN' in process.env) {
+  console.log('It worked!'); // eslint-disable-line no-console
+}
+
 export default App;


### PR DESCRIPTION
This PR adds the Mapbox tokens to the appropriate `.env` files for use in the production and development sites.

Reopens: #66 