### PR TITLE
Update map style to be the default style (looks nicer)

### DIFF
--- a/src/containers/Map.js
+++ b/src/containers/Map.js
@@ -29,7 +29,7 @@ class Map extends Component {
           {...viewport} // eslint-disable-line react/jsx-props-no-spreading
           onViewportChange={(newView) => this.setState({ viewport: newView })}
           mapboxApiAccessToken={process.env.REACT_APP_MAPBOX_TOKEN}
-          mapStyle="mapbox://styles/mapbox/dark-v10"
+          mapStyle="mapbox://styles/mapbox/streets-v11"
         />
       </>
     );


### PR DESCRIPTION
We should reserve the dark theme for when the OS is in dark mode (this theme is currently a million times more readable).

**Screenshot:**
![image](https://user-images.githubusercontent.com/19293725/75597746-ded1bd80-5a5c-11ea-90f5-4884cdca9dbe.png)