### PR TITLE
Login component should take strings as props

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -68,8 +68,8 @@ class App extends Component {
     if (!loggedIn) {
       return (
         <Login
-          loginAddress={Auth.loginAddress()}
-          signUpAddress={Auth.signUpAddress()}
+          loginAddress={Auth.loginAddress().href}
+          signUpAddress={Auth.signUpAddress().href}
         />
       );
     }

--- a/src/components/Login.js
+++ b/src/components/Login.js
@@ -41,18 +41,8 @@ const Login = ({ loginAddress, signUpAddress }) => (
 );
 
 Login.propTypes = {
-  loginAddress: PropTypes.shape({
-    href: PropTypes.string,
-    origin: PropTypes.string,
-    host: PropTypes.string,
-    hostname: PropTypes.string,
-  }).isRequired,
-  signUpAddress: PropTypes.shape({
-    href: PropTypes.string,
-    origin: PropTypes.string,
-    host: PropTypes.string,
-    hostname: PropTypes.string,
-  }).isRequired,
+  loginAddress: PropTypes.string.isRequired,
+  signUpAddress: PropTypes.string.isRequired,
 };
 
 export default Login;


### PR DESCRIPTION
Previously, the `Login` component was accepting `url` objects as props, but we want to accept string to make the component as dumb as possible.