### PR TITLE
Add keys to the StarRating component

### DIFF
--- a/src/components/StarRating.js
+++ b/src/components/StarRating.js
@@ -11,6 +11,7 @@ const StarRating = ({ rating, total }) => (
   <div className="StarRating">
     {[...Array(total)].map((x, i) => (
       <Icon
+        key={i} // eslint-disable-line react/no-array-index-key
         type="star"
         theme={starFilled(i, rating) ? 'filled' : ''}
         className={starFilled(i, rating) ? 'star-filled' : 'star-empty'}


### PR DESCRIPTION
Closes #80 

## The Problem 

The `StarRating` component generates a number of stars. 

React is complaining that each star doesn't have a unique `key` prop. This assigns a `key` prop to each icon. [Reference documentation on Lists & Keys](https://reactjs.org/docs/lists-and-keys.html#keys)

<img width="936" alt="Screen Shot 2020-02-29 at 5 57 00 PM" src="https://user-images.githubusercontent.com/13937038/75616907-e48ed800-5b1c-11ea-8f49-bd3fbaa1ae50.png">


## Solution

Give each star an ID based on the array index when generating it

### Problems with this 
It is considered a bit of an [anti-pattern](https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318) to use the array index as a key (as we are doing here) 

However, there are exceptions to the rule, and this component falls under the exception, as we are not recording the icons and the items have no distinct IDs.



<img width="957" alt="Screen Shot 2020-02-29 at 12 18 00 PM" src="https://user-images.githubusercontent.com/13937038/75616873-5e729180-5b1c-11ea-93a9-99be0f73045d.png">

## Result
As such it's safe to use the array position as the key and disable the listing on this line.