### PR TITLE
Add generic NearMeList component

### DIFF
--- a/src/components/NearMeList.js
+++ b/src/components/NearMeList.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { List, Rate } from 'antd';
+
+const NearMeList = ({ data, fetching }) => (
+  <List
+    className="near-me-list"
+    loading={fetching}
+    bordered
+    dataSource={data}
+    renderItem={(item) => (
+      <List.Item className="near-me-list-item">
+        {item.title}
+        <br />
+        <Rate
+          disabled
+          allowHalf
+          value={item.overall_rating}
+        />
+      </List.Item>
+    )}
+  />
+);
+
+NearMeList.propTypes = {
+  data: PropTypes.instanceOf(Array),
+  fetching: PropTypes.bool,
+};
+
+NearMeList.defaultProps = {
+  data: [],
+  fetching: false,
+};
+
+export default NearMeList;

--- a/src/components/__tests__/NearMeList.test.js
+++ b/src/components/__tests__/NearMeList.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+
+import NearMeList from '../NearMeList';
+
+const washrooms = [
+  {
+    title: 'Washroom 1',
+    overall_rating: 3.0,
+  }, {
+    title: 'Washroom 2',
+    overall_rating: 4.5,
+  },
+];
+
+describe('Nav', () => {
+  it('Renders the Nav page', () => {
+    const component = mount(
+      <NearMeList
+        data={washrooms}
+        isFetching={false}
+      />,
+    );
+
+    expect(component.find('List Item').length).toEqual(2);
+
+    const washroom1 = component.find('List Item').at(0);
+    expect(washroom1.text()).toEqual('Washroom 1');
+    expect(washroom1.find('Rate').at(0).prop('value')).toEqual(3);
+
+    const washroom2 = component.find('List Item').at(1);
+    expect(washroom2.text()).toEqual('Washroom 2');
+    expect(washroom2.find('Rate').at(0).prop('value')).toEqual(4.5);
+  });
+});

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,4 +1,5 @@
 import Nav from './Nav';
 import Login from './Login';
+import NearMeList from './NearMeList';
 
-export { Nav, Login };
+export { Nav, Login, NearMeList };

--- a/src/containers/NearMe.js
+++ b/src/containers/NearMe.js
@@ -2,13 +2,13 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
   Typography,
-  List,
   Icon,
-  Rate,
 } from 'antd';
 
 import { connect } from 'react-redux';
 import { getWashrooms } from '../actions/washroomActions';
+
+import NearMeList from '../components/NearMeList';
 
 const { Title } = Typography;
 
@@ -34,25 +34,10 @@ class NearMe extends Component {
       <>
         <Icon type="environment" className="icon-title" />
         <Title>Near Me</Title>
-        <pre>
-          { JSON.stringify(this.props) }
-        </pre>
-        <List
-          className="near-me-list"
-          loading={isFetching}
-          bordered
-          dataSource={washrooms}
-          renderItem={(item) => (
-            <List.Item className="near-me-list-item">
-              {item.title}
-              <br />
-              <Rate
-                disabled
-                allowHalf
-                value={item.overall_rating}
-              />
-            </List.Item>
-          )}
+
+        <NearMeList
+          data={washrooms}
+          fetching={isFetching}
         />
       </>
     );


### PR DESCRIPTION
Since our `NearMe` page is going to have a list of both `washrooms` and `buildings`, have a generic component to render the list for either.

This is going to make our NearMe component much cleaner once we add functionality to fetch buildings.