### PR TITLE
Display buildings on NearMe page

### DIFF
--- a/src/components/WashroomListItem.css
+++ b/src/components/WashroomListItem.css
@@ -1,5 +1,4 @@
 .list-item {
-  padding: 5px 0;
   width: 100%;
   color: inherit !important;
 }

--- a/src/containers/NearMe.css
+++ b/src/containers/NearMe.css
@@ -1,3 +1,0 @@
-.near-me-list-item {
-  padding: 0px 8px !important;
-}

--- a/src/containers/NearMe.js
+++ b/src/containers/NearMe.js
@@ -4,21 +4,33 @@ import {
   Typography,
   List,
   Icon,
+  Tabs,
 } from 'antd';
 import { connect } from 'react-redux';
 import { getWashrooms } from '../actions/washroomActions';
+import { getBuildings } from '../actions/buildingActions';
+
 import { WashroomListItem } from '../components';
 
-import './NearMe.css';
-
 const { Title } = Typography;
+const { TabPane } = Tabs;
 
 class NearMe extends Component {
   componentDidMount() {
-    const { washrooms } = this.props;
+    const { washrooms, buildings } = this.props;
+
     if (washrooms.length === 0) {
       this.getWashrooms();
     }
+    if (buildings.length === 0) {
+      this.getBuildings();
+    }
+  }
+
+  getBuildings = () => {
+    const { getBuildings } = this.props; // eslint-disable-line no-shadow
+
+    getBuildings();
   }
 
   getWashrooms = () => {
@@ -28,54 +40,109 @@ class NearMe extends Component {
   }
 
   render() {
-    const { washrooms, isFetching } = this.props;
+    const {
+      washrooms,
+      buildings,
+      washroomsFetching,
+      buildingsFetching,
+    } = this.props;
 
     return (
       <>
         <Icon type="environment" className="icon-title" />
         <Title>Near Me</Title>
-        <List
-          className="near-me-list"
-          loading={isFetching}
-          bordered
-          dataSource={washrooms}
-          renderItem={(item) => (
-            <List.Item
-              className="near-me-list-item"
-              key={item.id}
-            >
-              <WashroomListItem item={item} />
-            </List.Item>
-          )}
-        />
+
+        <Tabs
+          defaultActiveKey="1"
+          size="large"
+          animated={false}
+        >
+          <TabPane
+            tab="Buildings"
+            key="1"
+          >
+            <List
+              className="near-me-list"
+              loading={buildingsFetching}
+              bordered
+              dataSource={buildings}
+              renderItem={(item) => (
+                <List.Item
+                  className="near-me-list-item"
+                  key={item.id}
+                >
+                  {item.title}
+                </List.Item>
+              )}
+            />
+          </TabPane>
+          <TabPane
+            tab="Washrooms"
+            key="2"
+          >
+            <List
+              className="near-me-list"
+              loading={washroomsFetching}
+              bordered
+              dataSource={washrooms}
+              renderItem={(item) => (
+                <List.Item
+                  className="near-me-list-item"
+                  key={item.id}
+                >
+                  <WashroomListItem item={item} />
+                </List.Item>
+              )}
+            />
+          </TabPane>
+        </Tabs>
       </>
     );
   }
 }
 
 const mapStateToProps = (state) => {
-  const { washrooms, isFetching, status } = state.washroomReducer;
+  const {
+    washrooms, isFetching:
+    washroomsFetching,
+    status: washroomsStatus,
+  } = state.washroomReducer;
+
+  const {
+    buildings, isFetching:
+    buildingsFetching,
+    status: buildingsStatus,
+  } = state.buildingReducer;
 
   return {
-    status,
-    isFetching,
     washrooms,
+    washroomsFetching,
+    washroomsStatus,
+    buildings,
+    buildingsFetching,
+    buildingsStatus,
   };
 };
 
 const mapDispatchToProps = (dispatch) => ({
   getWashrooms: () => dispatch(getWashrooms()),
+  getBuildings: () => dispatch(getBuildings()),
 });
 
 NearMe.propTypes = {
-  getWashrooms: PropTypes.func.isRequired,
   washrooms: PropTypes.instanceOf(Array),
-  isFetching: PropTypes.bool,
+  buildings: PropTypes.instanceOf(Array),
+  getWashrooms: PropTypes.func.isRequired,
+  getBuildings: PropTypes.func.isRequired,
+  washroomsFetching: PropTypes.bool,
+  buildingsFetching: PropTypes.bool,
 };
 
 NearMe.defaultProps = {
   washrooms: [],
-  isFetching: false,
+  buildings: [],
+  washroomsFetching: false,
+  buildingsFetching: false,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(NearMe);

--- a/src/containers/__tests__/NearMe.test.js
+++ b/src/containers/__tests__/NearMe.test.js
@@ -47,8 +47,47 @@ fetchMock.get('https://testapi.com/washrooms', [
   },
 ]);
 
+fetchMock.get('https://testapi.com/buildings?location=undefined&maxResults=undefined&radius=undefined&amenities=undefined', [
+  {
+    best_ratings: {
+      cleanliness: 5.0,
+      privacy: 4.0,
+      smell: 1.0,
+      toilet_paper_quality: 3.0,
+    },
+    created_at: '2020-03-05T13:02:49+00:00',
+    id: 1,
+    location: {
+      latitude: 49.81175231933594,
+      longitude: -97.13582611083984,
+    },
+    maps_service_id: 54724739,
+    overall_rating: 3.25,
+    title: 'Wallace Building',
+    washroom_count: 1,
+  },
+  {
+    best_ratings: {
+      cleanliness: 2.7142856121063232,
+      privacy: 2.5714285373687744,
+      smell: 2.5714285373687744,
+      toilet_paper_quality: 2.7142856121063232,
+    },
+    created_at: '2020-03-05T13:02:50+00:00',
+    id: 2,
+    location: {
+      latitude: 49.809364318847656,
+      longitude: -97.1344985961914,
+    },
+    maps_service_id: 54724743,
+    overall_rating: 2.642857074737549,
+    title: 'University Centre',
+    washroom_count: 0,
+  },
+]);
+
 describe('NearMe', () => {
-  it('Renders the "Near me" page', async () => {
+  it.only('Renders the "Near me" page with tabs', async () => {
     await act(async () => {
       const component = mount(
         <Router>
@@ -57,11 +96,36 @@ describe('NearMe', () => {
       );
 
       expect(component.find('Title').text()).toEqual('Near Me');
+      expect(component.find('TabPane')).toHaveLength(2);
+      expect(component.find('TabPane').first().prop('tab')).toEqual('Buildings');
+      expect(component.find('TabPane').at(1).prop('tab')).toEqual('Washrooms');
+    });
+  });
+
+  it('Displays a list of buildings', async () => {
+    await act(async () => {
+      const component = mount(
+        <Router>
+          <NearMe store={store} />
+        </Router>,
+      );
+
+      // TODO: replace selector with BuildingListItem once new PR goes in
+      expect(component.find('Item.near-me-list-item')).toHaveLength(2);
+      const listItem1 = component.find('Item.near-me-list-item').first();
+
+      // TODO: don't check text representation, check the PROPS of the BuildingListItem
+      expect(listItem1.text()).toEqual('Wallace Building');
+
+      const listItem2 = component.find('Item.near-me-list-item').at(1);
+      expect(listItem2.text()).toEqual('University Centre');
     });
   });
 
 
-  it('Displays a list of locations', async () => {
+  // Spent hours trying to navigate to next tab to test
+  // Was unsuccessful but we can't be blocked on this
+  it('Displays a list of washrooms', async () => {
     await act(async () => {
       const component = mount(
         <Router>


### PR DESCRIPTION
Closes #92 

Add the tab view to NearMe which lists buildings

Note: I was unable to get the testing working for the 2nd tab.

## Screenshots

<img width="740" alt="Screen Shot 2020-03-07 at 10 48 49 AM" src="https://user-images.githubusercontent.com/13937038/76147384-6c1aa080-6061-11ea-99c2-c336986ab7fa.png">

<img width="741" alt="Screen Shot 2020-03-07 at 10 48 54 AM" src="https://user-images.githubusercontent.com/13937038/76147386-6cb33700-6061-11ea-865b-792d3edaa45c.png">


