### PR TITLE
Add mobile friendly style

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,17 +1,26 @@
 @import '~antd/dist/antd.css';
 
 .app-background {
-    background: rgb(93,163,231);
-    background: linear-gradient(0deg, rgba(93,163,231,1) 0%, rgba(124,214,255,1) 100%);
+  background: rgb(93,163,231);
+  background: linear-gradient(0deg, rgba(93,163,231,1) 0%, rgba(124,214,255,1) 100%);
 }
 
 .app-content {
-    padding: 30px 50px;
-    min-height: 100vh;
+  padding: 30px 0;
+  width: 100%;
+  max-width: 1200px;
+  margin: auto;
+  min-height: 100vh;
+}
+
+@media only screen and (max-width: 1000px) {
+  .app-content {
+    padding: 0;
+  }
 }
 
 .app-switch-container {
-    background: #fff;
-    padding: 24px;
-    min-height: 280px;
+  background: #fff;
+  padding: 30px 15px;
+  min-height: 280px;
 }

--- a/src/components/Nav.css
+++ b/src/components/Nav.css
@@ -5,3 +5,11 @@
 .ant-menu.nav-menu {
   line-height: 64px;
 }
+
+.ant-layout-header {
+  padding: 0 !important;
+}
+.ant-menu-dark.ant-menu-horizontal {
+  max-width: 1200px;
+  margin: auto;
+}


### PR DESCRIPTION
Closes #90 

## Changes
- Add a max width to the container so it doesn't stretch to ridiculous sizes on big displays
- Reduce padding on mobile to more effectively use screen real estate

## Desktop
### Before
<img width="1687" alt="Screen Shot 2020-03-07 at 10 43 44 PM" src="https://user-images.githubusercontent.com/13937038/76156850-bf263f00-60c5-11ea-85c9-6ecf21041120.png">

### After
<img width="1687" alt="Screen Shot 2020-03-07 at 10 43 46 PM" src="https://user-images.githubusercontent.com/13937038/76156832-6bb3f100-60c5-11ea-8536-105f8c983445.png">

## Mobile

### Before
<img width="506" alt="Screen Shot 2020-03-07 at 10 44 20 PM" src="https://user-images.githubusercontent.com/13937038/76156815-4aeb9b80-60c5-11ea-937e-487864a34b38.png">

### After
<img width="453" alt="Screen Shot 2020-03-07 at 10 44 25 PM" src="https://user-images.githubusercontent.com/13937038/76156816-4b843200-60c5-11ea-83bc-4a789321bb73.png">
